### PR TITLE
added single-product-type-view

### DIFF
--- a/app/views/product_types/index.html.erb
+++ b/app/views/product_types/index.html.erb
@@ -2,8 +2,9 @@
 <ul class="list-group">
     <% @product_types.each do |pt|%>
         <li class="list-group-item justify-content-between">
-            <%= pt.product_type_name%>
+            <h2><%= link_to pt.product_type_name, product_type_path(pt)%>
             <span class="badge badge-default badge-pill">(<%= @products_by_type[pt[:id]].length %>)</span>
+            </h2>
             <% if @products_by_type[pt[:id]] != [] %>
                 <ul>
                     <% 3.times do |p|%>


### PR DESCRIPTION
#### Descriptions
Add a page that shows all products for a specific category with a link to each products individual page.

#### Steps to Test

1. Click on a single product category from the drop down menu, and from the all categories page. 
2. Both ways of navigation should take you to that specific category and show its products.
3. Click the more info link on one of the products and the product page for that product should show.

#### Link to Feature Ticket

#12 
#13 