### PR TITLE
number of items in cart indicator working

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -9,6 +9,7 @@ class OrderDetailsController < ApplicationController
         @order_detail = OrderDetail.new(order_detail_params)
         @order_detail.order_id = session[:order_id]
         @order_detail.save
+        redirect_back fallback_location: order_details_path
     end
 
     def destroy

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,10 @@ module ApplicationHelper
     def logged_in?
         @current_customer ||= Customer.find(session[:customer_id]) if session[:customer_id]  # puts @current_customer
     end
+
+    def number_of_items_in_cart
+        @cart_number = OrderDetail.where({order_id: session[:order_id]})
+        return @cart_number.length
+    end
+    
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,12 +32,15 @@
                 <a class="nav-link" href="/products/new" id="sell">Sell</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/order_details" id="cart">Cart</a>
+                <% if number_of_items_in_cart  == 0 %>
+                    <a class="nav-link" href="/order_details" id="cart">Cart</a>
+                <% else %> 
+                    <a class="nav-link" href="/order_details" id="cart">Cart(<%= number_of_items_in_cart %>)</a>
+                <% end %>
             </li>
             <li class="nav-item">
 
             <% end %>
-                <%# <a class="nav-link" href="#" id="cart">Cart</a> %>
                 <% if logged_in? %>
                     <%= link_to 'Profile', customer_path(@current_customer.id), {:class => "nav-link"} %>
                 <% end %>
@@ -55,7 +58,6 @@
                         <%= link_to "Log In", login_path, {:class => "nav-link"} %>
                     <% end %>
             </li>
-
         </ul>
 
         <%= form_tag('/products/search', method: "get", id: "searchbar", class: "form-inline my-2 my-lg-0") do %>


### PR DESCRIPTION
## Pull Requests
#### Descriptions

1. Added feature where the number of items in the current shopping cart appears next to the 'Cart' nav item. 
1. The method that checks the Order Detail table lives in app>helpers>application.rb so it id available app-wide.

#### Steps to Test

You must provide clear steps for any teammate to test the code.

1. Add stuff to your cart, preferably something awesome like a four-wheeler or a copy of Led Zeppelin IV on vinyl.
1. Make sure the number displayed in the nav bar is the same as the number of things in your cart/

#### Link to Feature Ticket
n/a
