### PR TITLE
Profanity filter

### DIFF
--- a/app/assets/stylesheets/global_styles.scss
+++ b/app/assets/stylesheets/global_styles.scss
@@ -31,3 +31,7 @@ footer {
     display: table-cell;
     vertical-align: middle;
 }
+
+.red {
+    color: red;
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,11 +20,23 @@ class ProductsController < ApplicationController
     end
 
     def create
+        regex = curses
         @product = Product.new(product_params)
-        if @product.save
-            redirect_to @product
-        else
+        if @product.product_name.match(regex)&&@product.product_desc.match(regex)
+            flash.now[:notice] = "Your product name and description must be free of profanity." 
             render 'new'
+        elsif @product.product_name.match(regex)
+            flash.now[:notice] = "Your product name must be free of profanity." 
+            render 'new'
+        elsif @product.product_desc.match(regex)
+            flash.now[:notice] = "Your product description must be free of profanity." 
+            render 'new'
+        else
+            if @product.save
+                redirect_to @product
+            else
+                render 'new'
+            end
         end
     end
 
@@ -40,6 +52,7 @@ class ProductsController < ApplicationController
     end
 
     private
+
         def product_params
             params.require(:product).permit(:customer_id, :product_type_id, :product_name, :product_price, :product_desc, :quantity, :product_location, :avatar)
         end
@@ -47,5 +60,10 @@ class ProductsController < ApplicationController
         def cannot_delete
             redirect_to products_path
             flash[:notice] = 'This product is part of an order and cannot be deleted.'
+        end
+
+        def curses
+            regexArray = [/([Ss]hit(, )?)+/,/([Pp]iss(, )?)+/, /([Ff]uck(, )?)+/, /([Cc]unt(, )?)+/, /([Cc]ocksucker(, )?)+/, /([Mm]otherfucker(, )?)+/, /([Tt]its(, )?)+/, /([Aa]ss(, )?)+/, /([Tt]wat(, )?)+/]
+            return Regexp.union(regexArray)
         end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -63,7 +63,7 @@ class ProductsController < ApplicationController
         end
 
         def curses
-            regexArray = [/([Ss]hit(, )?)+/,/([Pp]iss(, )?)+/, /([Ff]uck(, )?)+/, /([Cc]unt(, )?)+/, /([Cc]ocksucker(, )?)+/, /([Mm]otherfucker(, )?)+/, /([Tt]its(, )?)+/, /([Aa]ss(, )?)+/, /([Tt]wat(, )?)+/]
+            regexArray = [/([Ss]hit(, )?)+/i,/([Pp]iss(, )?)+/i, /([Ff]uck(, )?)+/i, /([Cc]unt(, )?)+/i, /([Cc]ock(, )?)+/i, /([Mm]otherfucker(, )?)+/i, /([Tt]its(, )?)+/i, /([Aa]ss(, )?)+/i, /([Tt]wat(, )?)+/i, /([Bb]itch(, )?)+/i, /([Pp]ussy(, )?)+/i, /([Ff]ag(, )?)+/i, /([Ss]lut(, )?)+/i]
             return Regexp.union(regexArray)
         end
 end

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -3,6 +3,7 @@
     <div class="col-md-8">
       <br>
       <h2>Create a Product to Sell</h2>
+      <h5 class="red"><%= flash[:notice] %></h5>
       <br>
       
       <%= form_with scope: :product, url: products_path, local: true, html: { multipart: true } do |form| %>


### PR DESCRIPTION
## Pull Request

#### Description

The description that you provide should be comprehensive enough to...

1. When adding a product, the app will now detect common profanity in the product name and description and flash an alert.

#### Steps to Test

1. navigate to "Sell"
1. Enter all the fields but use a common swear in the product name field - an alert stating that profanity is not allowed in the product name field should occur.
1. Enter all the fields but use a common swear in the product DESCRIPTION field - an alert stating that profanity is not allowed in the product description field should occur.
1. Enter all the fields but use a common swear in the product DESCRIPTION and Product NAME field - an alert stating that profanity is not allowed in the product description field or product name should occur

#### Link to Feature Ticket

https://github.com/c-cannons/bangazon-initial_site/issues/27
